### PR TITLE
Add newline terminator to "Hello, word!"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
 int main() {
-    std::cout << "Hello, world!";
+    std::cout << "Hello, world!\n";
     return 0;
 }


### PR DESCRIPTION
It is very important to end programs with a newline terminator for reasons like:

- if a parent program ran the child program (this one in this case), after exit time of the child call, the parent program will output text on the terminal in the same line if it does not check for the last character.
- some programs like unix shells may get confused when the last character is not a '\n' newline character (see image below).
  ![image](https://github.com/mine-chad/server/assets/53640879/5708c9e0-1d62-4a29-8d59-76871fef18df)
- it's a good practice and maybe even a standard to use a newline terminator when outputing to the `stdout`, `stdwarn` and `stderr` files.